### PR TITLE
Add xru build, fix f_inmsg calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,24 @@
 PROJECT = xr
 
 $(PROJECT).prg: $(PROJECT).asm bios.inc
+	../../dateextended.pl > date.inc
+	../../build.pl > build.inc
 	rcasm -l -v -x -d 1802 $(PROJECT) 2>&1 | tee $(PROJECT).lst
 	cat $(PROJECT).prg | sed -f adjust.sed > x.prg
 	rm $(PROJECT).prg
 	mv x.prg $(PROJECT).prg
 
 bios: $(PROJECT).asm bios.inc
+	../../dateextended.pl > date.inc
+	../../build.pl > build.inc
 	rcasm -l -v -x -d 1802 -DXRB $(PROJECT) 2>&1 | tee $(PROJECT).lst
 	cat $(PROJECT).prg | sed -f adjust.sed > x.prg
 	rm $(PROJECT).prg
 	mv x.prg $(PROJECT).prg
 
 uart: $(PROJECT).asm bios.inc
+	../../dateextended.pl > date.inc
+	../../build.pl > build.inc
 	rcasm -l -v -x -d 1802 -DXRU $(PROJECT) 2>&1 | tee $(PROJECT).lst
 	cat $(PROJECT).prg | sed -f adjust.sed > x.prg
 	rm $(PROJECT).prg

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 PROJECT = xr
 
 $(PROJECT).prg: $(PROJECT).asm bios.inc
-	../../dateextended.pl > date.inc
-	../../build.pl > build.inc
 	rcasm -l -v -x -d 1802 $(PROJECT) 2>&1 | tee $(PROJECT).lst
 	cat $(PROJECT).prg | sed -f adjust.sed > x.prg
 	rm $(PROJECT).prg
 	mv x.prg $(PROJECT).prg
 
 bios: $(PROJECT).asm bios.inc
-	../../dateextended.pl > date.inc
-	../../build.pl > build.inc
 	rcasm -l -v -x -d 1802 -DXRB $(PROJECT) 2>&1 | tee $(PROJECT).lst
+	cat $(PROJECT).prg | sed -f adjust.sed > x.prg
+	rm $(PROJECT).prg
+	mv x.prg $(PROJECT).prg
+
+uart: $(PROJECT).asm bios.inc
+	rcasm -l -v -x -d 1802 -DXRU $(PROJECT) 2>&1 | tee $(PROJECT).lst
 	cat $(PROJECT).prg | sed -f adjust.sed > x.prg
 	rm $(PROJECT).prg
 	mv x.prg $(PROJECT).prg


### PR DESCRIPTION
Add variation and build target for xru version which transfers through UART (via BIOS) rather than through the current console device. Change a couple of calls to f_inmsg to o_inmsg.